### PR TITLE
Reuse connections – man page

### DIFF
--- a/help.c
+++ b/help.c
@@ -210,7 +210,7 @@ void usage(const char *me)
 	format_help(NULL, "--divert-connect", gettext("connect to a different host than in the URL given"));
 	format_help(NULL, "--keep-cookies", gettext("return the cookies given by the HTTP server in the following request(s)"));
 	format_help(NULL, "--no-host-header", gettext("do not add \"Host:\"-line to the request headers"));
-	format_help("-Q", "--persistent-connections", gettext("use a persistent connection. adds a 'C' to the output if httping had to reconnect"));
+	format_help("-Q", "--persistent-connections", gettext("use a persistent connection, i.e. reuse the same TCP connection for multiple HTTP requests. usually possible when 'Connection: Keep-Alive' is sent by server. adds a 'C' to the output if httping had to reconnect"));
 	format_help("-I x", "--user-agent", gettext("use 'x' for the UserAgent header"));
 	format_help("-R x", "--referer", gettext("use 'x' for the Referer header"));
 	format_help(NULL, "--header", gettext("adds an extra request-header"));

--- a/httping-nl.1
+++ b/httping-nl.1
@@ -93,6 +93,9 @@ Selecteer de HTTP status-codes die als 'ok' beschouwd worden.
 .B "\-p portnumber"
 Gebruik dit on combinatie met h. Het zet het port-nummer om te pingen.
 .TP
+.B "\-Q"
+Gebruik een blijvende verbinding, dat wil zeggen hergebruiken dezelfde TCP-verbinding voor meerdere HTTP-verzoeken. Meestal mogelijk wanneer 'Connection: Keep-Alive' is verzonden door de server. Als het bestemmingssysteem de verbinding verbroken heeft, dan zal HTTPing een \"C\" toevoegen aan de uitvoer.
+.TP
 .B "\-q"
 Geef geen uitvoer, alleen een teruggave code.
 .TP

--- a/httping.1
+++ b/httping.1
@@ -99,6 +99,9 @@ Be quiet, only return an exit-code.
 .B "\-R str"
 Referer-string to send to the webserver.
 .TP
+.B "\-Q"
+Use a persistent connection, i.e. reuse the same TCP connection for multiple HTTP requests. Usually possible when 'Connection: Keep-Alive' is sent by server. Adds a 'C' to the output if httping had to reconnect.
+.TP
 .B "\-r"
 Only resolve the hostname once: this takes the resolving out of the loop so that the latency of the DNS is not measured. Also useful when you want to measure only 1 webserver while the DNS returns a different ip-address for each resolve ('roundrobin').
 .TP

--- a/main.c
+++ b/main.c
@@ -1035,8 +1035,8 @@ int main(int argc, char *argv[])
 	bps.Bps_avg = 0;
 
 	setlocale(LC_ALL, "");
-	bindtextdomain("HTTPing", LOCALEDIR);
-	textdomain("HTTPing");
+	bindtextdomain("httping", LOCALEDIR);
+	textdomain("httping");
 
 	init_statst(&t_resolve);
 	init_statst(&t_connect);

--- a/nl.po
+++ b/nl.po
@@ -187,8 +187,8 @@ msgid "do not add \"Host:\"-line to the request headers"
 msgstr "voeg geen \"Host:\"-regel in het verbindingsverzoek"
 
 #: help.c:212
-msgid "use a persistent connection. adds a 'C' to the output if httping had to reconnect"
-msgstr "gebruik een blijvende verbinding. als het bestemmingssysteem de verbinding verbroken heeft, dan zal HTTPing een \"C\" toevoegen aan de uitvoer"
+msgid "use a persistent connection, i.e. reuse the same TCP connection for multiple HTTP requests. usually possible when 'Connection: Keep-Alive' is sent by server. adds a 'C' to the output if httping had to reconnect"
+msgstr "gebruik een blijvende verbinding, dat wil zeggen hergebruiken dezelfde TCP-verbinding voor meerdere HTTP-verzoeken. meestal mogelijk wanneer 'Connection: Keep-Alive' is verzonden door de server. als het bestemmingssysteem de verbinding verbroken heeft, dan zal HTTPing een \"C\" toevoegen aan de uitvoer"
 
 #: help.c:213
 msgid "use 'x' for the UserAgent header"


### PR DESCRIPTION
Clarification about the `-Q` option. Google translated Dutch localisation too, most probably very clumsily.

Also fixed textdomain because otherwise locale wouldn't work.