### PR TITLE
Fix segfault with -M flag and invalid address

### DIFF
--- a/error.c
+++ b/error.c
@@ -11,6 +11,8 @@
 
 char last_error[4096] = { 0 };
 
+extern char json_output;
+
 void error_exit(char *format, ...)
 {
 	int e = errno;
@@ -19,6 +21,10 @@ void error_exit(char *format, ...)
 	va_start(ap, format);
 	(void)vfprintf(stderr, format, ap);
 	va_end(ap);
+
+	if (json_output) {
+	  printf("\n]\n");
+	}
 
 	fprintf(stderr, gettext("\n\nerrno=%d which means %s (if applicable)\n"), e, strerror(e));
 

--- a/main.c
+++ b/main.c
@@ -175,8 +175,10 @@ void emit_json(char ok, int seq, double start_ts, stats_t *t_resolve, stats_t *t
 		printf("\"connect_ms\" : \"%e\", ", t_connect -> cur);
 	else
 		printf("\"connect_ms\" : \"%e\", ",-1.0);
-	printf("\"request_ms\" : \"%e\", ", t_request -> cur);
-	printf("\"total_ms\" : \"%e\", ", t_total -> cur);
+	if (t_request != NULL)
+		printf("\"request_ms\" : \"%e\", ", t_request -> cur);
+	if (t_total != NULL)
+		printf("\"total_ms\" : \"%e\", ", t_total -> cur);
 	printf("\"http_code\" : \"%d\", ", http_code);
 	printf("\"msg\" : \"%s\", ", msg);
 	printf("\"header_size\" : \"%d\", ", header_size);
@@ -186,13 +188,15 @@ void emit_json(char ok, int seq, double start_ts, stats_t *t_resolve, stats_t *t
 	printf("\"ssl_fingerprint\" : \"%s\", ", ssl_fp ? ssl_fp : "");
 	printf("\"time_offset\" : \"%f\", ", toff_diff_ts);
 	printf("\"tfo_success\" : \"%s\", ", tfo_success ? "true" : "false");
-	if (t_ssl -> cur_valid)
+	if (t_ssl != NULL && t_ssl -> cur_valid)
 		printf("\"ssl_ms\" : \"%e\", ", t_ssl -> cur);
 	printf("\"tfo_succes\" : \"%s\", ", tfo_success ? "true" : "false");
 	if (t_ssl !=NULL && t_ssl -> cur_valid)
 		printf("\"ssl_ms\" : \"%e\", ", t_ssl -> cur);
-	printf("\"write\" : \"%e\", ", t_write -> cur);
-	printf("\"close\" : \"%e\", ", t_close -> cur);
+	if (t_write != NULL)
+		printf("\"write\" : \"%e\", ", t_write -> cur);
+	if (t_close != NULL)
+		printf("\"close\" : \"%e\", ", t_close -> cur);
 	printf("\"cookies\" : \"%d\", ", n_cookies);
 	if (stats_to != NULL && stats_to -> cur_valid)
 		printf("\"to\" : \"%e\", ", stats_to -> cur);


### PR DESCRIPTION
Segmentation fault when httping is used with the -M flag, for a JSON output, and an invalid address is given as parameter.
Example:
`$ httping -M helloworld`