### PR TITLE
removed redundant emit_error

### DIFF
--- a/main.c
+++ b/main.c
@@ -1753,7 +1753,6 @@ persistent_loop:
 
 			if (fd < 0)
 			{
-				emit_error(verbose, curncount, dstart);
 				fd = -1;
 			}
 


### PR DESCRIPTION
If the first `if (fd < 0)` (line 1754) is true the only functions that are call until the second `if (fd < 0)` (line 1802) are:
`get_ts()` which does not modify `fd` and does not call any functions that will modify the `fd`
`update_statst()` which does not call any other functions and does not modify `fd`

So when the first `if (fd < 0)` (line 1754)  is true the second one (line 1802) is automatically true and so the `emit_error(verbose, curncount, dstart);` is call twice in a row, and all parameters don't change.

If I'm wrong please tell me.