### PR TITLE
Fix complie error on my platform.

### DIFF
--- a/cookies.c
+++ b/cookies.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "utils.h"
 


### PR DESCRIPTION
I had to include that header on my platform to make compile go through.
Please let me know if there is better way to get around that issue.

```
% make
cc -Wall -W -Wextra -pedantic -D_FORTIFY_SOURCE=2  -DVERSION=\"2.6\" -DLOCALEDIR=\"/usr/share/locale\" -DTCP_TFO -DNC -D_DEBUG -ggdb   -c -o main.o main.c
main.c: In function ‘handler_quit’:
main.c:66:23: warning: unused parameter ‘s’ [-Wunused-parameter]
 void handler_quit(int s)
                       ^
cc -Wall -W -Wextra -pedantic -D_FORTIFY_SOURCE=2  -DVERSION=\"2.6\" -DLOCALEDIR=\"/usr/share/locale\" -DTCP_TFO -DNC -D_DEBUG -ggdb   -c -o cookies.o cookies.c
In file included from cookies.c:4:0:
utils.h:19:15: error: unknown type name ‘useconds_t’
 void myusleep(useconds_t v);
               ^
<builtin>: recipe for target 'cookies.o' failed
make: *** [cookies.o] Error 1
```