### PR TITLE
Catch SSL hostname mismatches.

### DIFF
--- a/main.c
+++ b/main.c
@@ -1768,7 +1768,7 @@ persistent_loop:
 #ifndef NO_SSL
 				if (use_ssl && ssl_h == NULL)
 				{
-					int rc = connect_ssl(fd, client_ctx, &ssl_h, &s_bio, timeout, &ssl_handshake);
+					int rc = connect_ssl(fd, client_ctx, &ssl_h, &s_bio, timeout, &ssl_handshake, hostname);
 					if (rc == 0)
 						update_statst(&t_ssl, ssl_handshake);
 					else

--- a/mssl.c
+++ b/mssl.c
@@ -185,7 +185,7 @@ int WRITE_SSL(SSL *const ssl_h, const char *wherefrom, int len, const double tim
 	return cnt;
 }
 
-int connect_ssl(const int fd, SSL_CTX *const client_ctx, SSL **const ssl_h, BIO **const s_bio, const double timeout, double *const ssl_handshake)
+int connect_ssl(const int fd, SSL_CTX *const client_ctx, SSL **const ssl_h, BIO **const s_bio, const double timeout, double *const ssl_handshake, char *const hostname)
 {
 	double dstart = get_ts();
 	double end = get_ts() + timeout;
@@ -209,6 +209,9 @@ int connect_ssl(const int fd, SSL_CTX *const client_ctx, SSL **const ssl_h, BIO 
 	}
 
 	*ssl_h = SSL_new(client_ctx);
+
+	X509_VERIFY_PARAM *param = SSL_get0_param(*ssl_h);
+	X509_VERIFY_PARAM_set1_host(param, hostname, 0);
 
 	*s_bio = BIO_new_socket(fd, BIO_NOCLOSE);
 	SSL_set_bio(*ssl_h, *s_bio, *s_bio);

--- a/mssl.h
+++ b/mssl.h
@@ -9,7 +9,7 @@ void shutdown_ssl(void);
 int close_ssl_connection(SSL *const ssl_h);
 int READ_SSL(SSL *const ssl_h, char *whereto, int len, const double timeout);
 int WRITE_SSL(SSL *const ssl_h, const char *whereto, int len, const double timeout);
-int connect_ssl(const int fd, SSL_CTX *const client_ctx, SSL **const ssl_h, BIO **const s_bio, const double timeout, double *const ssl_handshake);
+int connect_ssl(const int fd, SSL_CTX *const client_ctx, SSL **const ssl_h, BIO **const s_bio, const double timeout, double *const ssl_handshake, char *const hostname);
 SSL_CTX * initialize_ctx(const char ask_compression, const char *ca_path);
 char * get_fingerprint(SSL *const ssl_h);
 int connect_ssl_proxy(const int fd, struct addrinfo *const ai, const double timeout, const char *const proxy_user, const char *const proxy_password, const char *const hostname, const int portnr, char *const tfo);


### PR DESCRIPTION
Prints `SSL certificate validation failed: Hostname mismatch` when it sees a mismatch.