### PR TITLE
Makefile: allow build without gettext

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,9 @@ MKDIR=/bin/mkdir
 ARCHIVE=/bin/tar cf -
 COMPRESS=/bin/gzip -9
 
+ifneq ($(NO_GETTEXT),yes)
 TRANSLATIONS=nl.mo ru.mo
+endif
 
 OBJS=gen.o http.o io.o error.o utils.o main.o tcp.o res.o socks5.o kalman.o cookies.o help.o colors.o
 
@@ -118,10 +120,12 @@ install: $(TARGET) $(TRANSLATIONS)
 ifneq ($(DEBUG),yes)
 	$(STRIP) $(DESTDIR)/$(BINDIR)/$(TARGET)
 endif
+ifneq ($(NO_GETTEXT),yes)
 	mkdir -p $(DESTDIR)/$(PREFIX)/share/locale/nl/LC_MESSAGES
 	cp nl.mo $(DESTDIR)/$(PREFIX)/share/locale/nl/LC_MESSAGES/httping.mo
 	mkdir -p $(DESTDIR)/$(PREFIX)/share/locale/ru/LC_MESSAGES
 	cp ru.mo $(DESTDIR)/$(PREFIX)/share/locale/ru/LC_MESSAGES/httping.mo
+endif
 
 
 makefile.inc:


### PR DESCRIPTION
The msgfmt command is part of the gettext package, and is used to generate
binary translation files. When gettext is not installed, build fails.
Translation files are not always needed on size constrained embedded targets.
Add an option to disable translation files generation using the NO_GETTEXT
variable.