### PR TITLE
Set SNI on TLS connections

### DIFF
--- a/mssl.c
+++ b/mssl.c
@@ -209,6 +209,7 @@ int connect_ssl(const int fd, SSL_CTX *const client_ctx, SSL **const ssl_h, BIO 
 	}
 
 	*ssl_h = SSL_new(client_ctx);
+	SSL_set_tlsext_host_name(*ssl_h, hostname);
 
 	X509_VERIFY_PARAM *param = SSL_get0_param(*ssl_h);
 	X509_VERIFY_PARAM_set1_host(param, hostname, 0);


### PR DESCRIPTION
Fixes #4 - I had a need for this, looked into it, and found that it's just one call. `httping` is now working for me on my site behind a CDN that depends on SNI.