### PR TITLE
Move LDFLAGS+=-lm option to the end.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,6 @@ DEBUG=yes
 WFLAGS=-Wall -W -Wextra -pedantic -D_FORTIFY_SOURCE=2
 OFLAGS=
 CFLAGS+=$(WFLAGS) $(OFLAGS) -DVERSION=\"$(VERSION)\" -DLOCALEDIR=\"$(LOCALEDIR)\"
-LDFLAGS+=-lm
 
 PACKAGE=$(TARGET)-$(VERSION)
 PREFIX?=/usr
@@ -98,6 +97,8 @@ endif
 ifeq ($(ARM),yes)
 CC=arm-linux-gcc
 endif
+
+LDFLAGS+=-lm
 
 all: $(TARGET) $(TRANSLATIONS)
 


### PR DESCRIPTION
The order of the math library directive '-lm' matters.

Signed-off-by: Yuvaraj Patil <yuvaraj.patil@wipro.com>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/httping/0001-fix-math-library-linking.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>